### PR TITLE
Update denoise_fmriprep_output.py

### DIFF
--- a/denoise_fmriprep_output.py
+++ b/denoise_fmriprep_output.py
@@ -31,7 +31,7 @@ for opt, arg in options:
         atlas = arg
     elif opt in ('-s', '--pipes'):
         mypipesstr = arg.replace(' ','')
-        mypipes    = arg.replace(' ','').replace('[','').replace(']','').split(',')
+        mypipes    = arg.replace(' ','').replace('[','').replace(']','').replace("'","").split(',')
         print(mypipesstr)
     elif opt in ('-o', '--overwrite'):
         overwrite = arg


### PR DESCRIPTION
The following error resulted because of the pipelines are in ' ', as per the README:
Invalid pipelines requested: '02P+AROMANonAgg' '03P+AROMANonAgg'

This change strips the single quotes from the argument to pipes and allows for comparisons with string character names for the pipelines.